### PR TITLE
fix: align project name with automation chart

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.2.2
 metadata:
-  name: ansible-devspaces-summit
+  name: ansible-dev-tools-workspace
 components:
   - name: tooling-container
     # --- BEGIN nested podman overrides ---
@@ -28,8 +28,8 @@ components:
       cpuLimit: 2000m
       env:
         - name: ANSIBLE_HOME
-          value: /projects/ansible-devspaces-summit/.ansible
+          value: /projects/ansible-dev-tools-workspace/.ansible
         - name: HOSTNAME
           value: ansible-devspaces
         - name: VSCODE_DEFAULT_WORKSPACE
-          value: /projects/ansible-devspaces-summit/devspaces.code-workspace
+          value: /projects/ansible-dev-tools-workspace/devspaces.code-workspace

--- a/devspaces.code-workspace
+++ b/devspaces.code-workspace
@@ -1,8 +1,8 @@
 {
     "folders": [
         {
-            "name": "ansible-devspaces-summit",
-            "path": "/projects/ansible-devspaces-summit"
+            "name": "ansible-dev-tools-workspace",
+            "path": "/projects/ansible-dev-tools-workspace"
         }
     ],
     "extensions": {


### PR DESCRIPTION
## Summary
- Renames all `ansible-devspaces-summit` references to `ansible-dev-tools-workspace` in `devfile.yaml` and `devspaces.code-workspace`
- Fixes duplicate folder in VS Code Explorer caused by name mismatch between this repo and the automation chart (`ansible-dev-tools-automation`), which clones this repo as `ansible-dev-tools-workspace`

## Test plan
- [ ] Deploy a new DevWorkspace and verify only one folder appears in the Explorer
- [ ] Verify `ANSIBLE_HOME` and `VSCODE_DEFAULT_WORKSPACE` env vars resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)