### PR TITLE
Bump ansible-devspaces image to v26.4.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This is a DevWorkspaces configuration repo for launching an Ansible-focused deve
 ## Key Files
 
 - **devfile.yaml** — Devfile v2.2.0 defining the workspace. Two components:
-  - `dev-tools`: Main container using a custom image (`quay.io/jpullen0/ansible-devspaces-nested-podman:opencode`) with rootless podman, `/dev/fuse` and `/dev/net/tun` device mappings, unmasked `/proc`, and `hostUsers: false` for user namespace isolation.
+  - `dev-tools`: Main container using a custom image (`ghcr.io/ansible/ansible-devspaces:v26.4.5`) with rootless podman, `/dev/fuse` and `/dev/net/tun` device mappings, unmasked `/proc`, and `hostUsers: false` for user namespace isolation.
   - `prep-workspace`: Init container that copies `oc` and `kubectl` binaries into `/projects/bin` before workspace start.
 - **devspaces.code-workspace** — VS Code multi-root workspace config with recommended extensions and Ansible-specific settings (linting with `--profile production --offline`, fully qualified collection names, podman as container engine).
 

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -21,7 +21,7 @@ components:
           procMount: Unmasked
     # --- END nested podman overrides ---
     container:
-      image: ghcr.io/ansible/ansible-devspaces:v26.4.4
+      image: ghcr.io/ansible/ansible-devspaces:v26.4.5
       memoryRequest: 2Gi
       memoryLimit: 4Gi
       cpuRequest: 500m


### PR DESCRIPTION
## Summary
- Updates devfile.yaml image tag from v26.4.4 to v26.4.5
- Removes obsolete `quay.io/jpullen0` image reference from CLAUDE.md

## Test plan
- [ ] DevWorkspace launches successfully with the new image
- [ ] Verify v26.4.5 image is available on GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)