### PR TITLE
Add SHELL env var, ADT_CONTAINER_ENGINE, and disable workspace trust

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -10,9 +10,13 @@ components:
       cpuRequest: 500m
       cpuLimit: 1000m
       env:
+        - name: SHELL
+          value: /bin/bash
         - name: ANSIBLE_HOME
           value: /projects/ansible-dev-tools-workspace/.ansible
         - name: HOSTNAME
           value: ansible-devspaces
         - name: VSCODE_DEFAULT_WORKSPACE
           value: /projects/ansible-dev-tools-workspace/devspaces.code-workspace
+        - name: ADT_CONTAINER_ENGINE
+          value: podman

--- a/devspaces.code-workspace
+++ b/devspaces.code-workspace
@@ -64,7 +64,7 @@
         "openshiftToolkit.searchForToolsInPath": true,
         "openshiftToolkit.execMaxBufferLength": 10,
         "python.useEnvironmentsExtension": false,
-        "security.workspace.trust.enabled": true,
+        "security.workspace.trust.enabled": false,
         "git.openRepositoryInParentFolders": "never",
         "redhat.telemetry.enabled": false
     }


### PR DESCRIPTION
## Summary
- Add `SHELL=/bin/bash` to devfile env — defensive fix for VS Code terminal spawning issues when SHELL is not set in the container environment (#11)
- Add `ADT_CONTAINER_ENGINE=podman` for tox podman support (from upstream ansible/ansible-dev-tools#735)
- Disable `security.workspace.trust.enabled` to reduce friction for lab participants

## Test plan
- [ ] Workspace starts successfully with new env vars
- [ ] `echo $SHELL` returns `/bin/bash` inside the workspace
- [ ] VS Code terminal spawns correctly
- [ ] No workspace trust popup on first open
- [ ] tox with podman works (`ADT_CONTAINER_ENGINE=podman`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)