### PR TITLE
Add terminal profiles to fix che-code terminal crash

### DIFF
--- a/devspaces.code-workspace
+++ b/devspaces.code-workspace
@@ -59,6 +59,15 @@
         "ansible.executionEnvironment.containerEngine": "podman",
         "git.autofetch": true,
         "ansible.lightspeed.enabled": false,
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+            "bash": {
+                "path": "/bin/bash"
+            },
+            "zsh": {
+                "path": "/bin/zsh"
+            }
+        },
         "terminal.integrated.scrollback": 10000,
         "openshiftToolkit.showWelcomePage": false,
         "openshiftToolkit.searchForToolsInPath": true,


### PR DESCRIPTION
## Summary
- Adds `terminal.integrated.defaultProfile.linux` and `terminal.integrated.profiles.linux` to workspace settings
- Potential workaround for the VS Code built-in terminal crash in che-code 3.27.0 (#11)
- Without explicit profiles, che-code's `parse` function receives `undefined` and crashes with `TypeError: can't access property "windows", e is undefined`

## Context
The default terminal (+ button, Ctrl+`, auto-open) fails on every tested tenant. The Che terminal path (Menu → Terminal → New Terminal, select container) works fine. See #11 for full investigation.

## Test plan
- [ ] Provision a new tenant with this change
- [ ] Verify the + button opens a bash terminal
- [ ] Verify no `resolveWithEnvironment` crash in browser console
- [ ] Verify Che terminal path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)