### PR TITLE
Test: rollback to v26.4.4 for terminal regression test

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tooling-container
     container:
-      image: ghcr.io/ansible/ansible-devspaces:v26.4.5
+      image: ghcr.io/ansible/ansible-devspaces:v26.4.4
       memoryRequest: 2Gi
       memoryLimit: 4Gi
       cpuRequest: 500m


### PR DESCRIPTION
## Summary
Rolls back `ansible-devspaces` image from v26.4.5 to v26.4.4 to test whether the VS Code terminal crash (#11) is a regression introduced by the image update.

If the terminal works with v26.4.4, the v26.4.5 image change is the trigger. This PR should be reverted after testing.

Tested in Firefox 149.0.2 and Chrome 147.0.7727.55 on Fedora 42 — same crash on both browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)