### PR TITLE
Revert to v26.4.5 after regression test

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tooling-container
     container:
-      image: ghcr.io/ansible/ansible-devspaces:v26.4.4
+      image: ghcr.io/ansible/ansible-devspaces:v26.4.5
       memoryRequest: 2Gi
       memoryLimit: 4Gi
       cpuRequest: 500m


### PR DESCRIPTION
## Summary
Restores v26.4.5 after confirming the terminal crash (#11) occurs on both v26.4.4 and v26.4.5. The rollback test (#14) ruled out the image as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)