### PR TITLE
Set ansible-navigator default mode to interactive

### DIFF
--- a/.ansible-navigator.yml
+++ b/.ansible-navigator.yml
@@ -14,7 +14,7 @@ ansible-navigator:
   playbook-artifact:
     enable: false
 
-  mode: stdout
+  mode: interactive
 
   color:
     enable: true


### PR DESCRIPTION
## Summary
- Change ansible-navigator default mode from `stdout` to `interactive` (TUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)